### PR TITLE
Add github action to build with cmake

### DIFF
--- a/.github/workflows/build-with-cmake.yml
+++ b/.github/workflows/build-with-cmake.yml
@@ -1,0 +1,33 @@
+name: Build with CMake
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env: 
+  PICO_SDK_PATH: ../pico-sdk
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: install dependencies
+      run: sudo apt update && sudo apt install -y cmake gcc-arm-none-eabi libnewlib-arm-none-eabi build-essential g++ libstdc++-arm-none-eabi-newlib
+    - name: download sdk
+      run: git clone --recurse-submodules https://github.com/raspberrypi/pico-sdk.git --branch master
+    - name: run cmake configure
+      run: cmake -DCMAKE_BUILD_TYPE=Release -S ./ -B ./build
+    - name: run cmake build
+      run: cmake --build ./build
+    - name: store build output-files
+      uses: actions/upload-artifact@v4
+      with:
+        name: cti_build
+        path: |
+         build/cti_*.elf*
+         build/cti_*.uf2


### PR DESCRIPTION
I have created a github action that can build the firmware files

Currently it just uploads the artefact to the run (the .uf2, and some .elf* files should they be needed for debugging)

The image appears to load and respond to an IDN? ok.

<img width="768" height="481" alt="image" src="https://github.com/user-attachments/assets/b323ca3c-e78c-4f65-836d-9d64923030c0" />

I am happy to tweak the triggers and it could be used to create github release (or draft releases) - feel free to make changes yourself or suggest any improvements.

